### PR TITLE
fix(develop): HEIA-5271 Rich Text: Pasting content does not paste it the same way

### DIFF
--- a/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
+++ b/Aztec/Classes/Formatters/Implementations/TextListFormatter.swift
@@ -32,6 +32,7 @@ class TextListFormatter: ParagraphAttributeFormatter {
         let newParagraphStyle = ParagraphStyle()
         if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
             newParagraphStyle.setParagraphStyle(paragraphStyle)
+            newParagraphStyle.removeProperty(ofType: HTMLParagraph.self)
         }
 
         let newList = TextList(style: self.listStyle, with: representation)
@@ -46,6 +47,70 @@ class TextListFormatter: ParagraphAttributeFormatter {
         resultingAttributes[.paragraphStyle] = newParagraphStyle
 
         return resultingAttributes
+    }
+    
+    func apply(to attributes: [NSAttributedString.Key: Any], newList: TextList) -> [NSAttributedString.Key: Any] {
+        let newParagraphStyle = ParagraphStyle()
+        if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
+            newParagraphStyle.setParagraphStyle(paragraphStyle)
+            newParagraphStyle.removeProperty(ofType: HTMLParagraph.self)
+        }
+        
+        if newParagraphStyle.lists.isEmpty || increaseDepth {
+            newParagraphStyle.insertProperty(newList, afterLastOfType: HTMLLi.self)
+        } else {
+            newParagraphStyle.replaceProperty(ofType: TextList.self, with: newList)
+        }
+
+        var resultingAttributes = attributes
+        resultingAttributes[.paragraphStyle] = newParagraphStyle
+
+        return resultingAttributes
+    }
+    
+    @discardableResult
+    func applyAttributes(to text: NSMutableAttributedString, at range: NSRange) -> NSRange {
+        let rangeToApply = applicationRange(for: range, in: text)
+
+        text.replaceOcurrences(of: String(.lineFeed), with: String(.paragraphSeparator), within: rangeToApply)
+        
+        var newList = TextList(style: self.listStyle, with: nil)
+
+        if let lastParagraphRange = text.paragraphRange(before: rangeToApply) {
+            let lastParaAttributes = text.attributes(at: lastParagraphRange.location, effectiveRange: nil)
+            
+            if let paraStyle = lastParaAttributes[.paragraphStyle] as? NSParagraphStyle,
+               let lastList = ParagraphStyle(with: paraStyle).lists.first, lastList.style == self.listStyle {
+                newList = lastList
+            }
+        }
+        var range = rangeToApply
+        while true {
+            if let nextParagraphRange = text.paragraphRange(after: range) {
+                var nextParaAttributes = text.attributes(at: nextParagraphRange.location, effectiveRange: nil)
+                
+                if let paraStyle = nextParaAttributes[.paragraphStyle] as? NSParagraphStyle {
+                    let newParaStyle = ParagraphStyle(with: paraStyle)
+                    if let nextList = newParaStyle.lists.first, nextList.style == self.listStyle,
+                        let listIndex = newParaStyle.properties.firstIndex(where: {Swift.type(of: $0) == TextList.self}) {
+                        newParaStyle.properties[listIndex] = newList
+                        nextParaAttributes[.paragraphStyle] = newParaStyle
+                        text.addAttributes(nextParaAttributes, range: nextParagraphRange)
+                        range = nextParagraphRange
+                        continue
+                    }
+                }
+            }
+            break
+        }
+        
+        text.enumerateAttributes(in: rangeToApply, options: []) { (attributes, range, _) in
+            let currentAttributes = text.attributes(at: range.location, effectiveRange: nil)
+            let attributes = apply(to: currentAttributes, newList: newList)
+            text.addAttributes(attributes, range: range)
+        }
+
+        return rangeToApply
     }
 
     func remove(from attributes: [NSAttributedString.Key: Any]) -> [NSAttributedString.Key: Any] {


### PR DESCRIPTION


When we select multiple paragraphs and apply ordered or un-ordered list style multiple `ol/ul` tags were created due to which the output of the html content was different in other html renderers.

So, We changed the behaviour and merged multiple `ol/ul` tags to single `ol/ul` tag.

Fixes #
HEIA-5271
